### PR TITLE
README has now a .adoc extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ YARD::Rake::YardocTask.new(:doc) do |yard|
   yard.files   = Dir['lib/**/*.rb']
   yard.options = [
     '--markup',        'markdown',
-    '--readme',        'README.md',
+    '--readme',        'README.adoc',
     '--files',         'NEWS.md,LICENSE',
     '--output-dir',    'doc/yardoc',
   ]


### PR DESCRIPTION
Hi!

This change modifies the yard options to reflect the fact that the README has now a .adoc extension and not a .md extension.

Cheers,

Cédric
