### PR TITLE
Feature/multiple options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cri (2.5.0)
-      colored (>= 1.2)
+      colored (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +17,6 @@ PLATFORMS
 
 DEPENDENCIES
   cri!
-  minitest
-  rake
-  yard
+  minitest (~> 5.3)
+  rake (~> 10.1)
+  yard (~> 0.8)

--- a/lib/cri/option_parser.rb
+++ b/lib/cri/option_parser.rb
@@ -16,8 +16,8 @@ module Cri
   # A sample array of definition hashes could look like this:
   #
   #     [
-  #       { :short => 'a', :long => 'all',  :argument => :forbidden },
-  #       { :short => 'p', :long => 'port', :argument => :required  },
+  #       { :short => 'a', :long => 'all',  :argument => :forbidden, :multiple => true },
+  #       { :short => 'p', :long => 'port', :argument => :required, :multiple => false },
   #     ]
   #
   # For example, the following commandline options (which should not be
@@ -258,7 +258,13 @@ module Cri
 
     def add_option(definition, value)
       key = (definition[:long] || definition[:short]).to_sym
-      options[key] = value
+      if definition[:multiple]
+        options[key] ||= []
+        options[key] << value
+      else
+        options[key] = value
+      end
+
       delegate.option_added(key, value, self) unless delegate.nil?
     end
 

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -5,13 +5,13 @@ class Cri::CommandDSLTestCase < Cri::TestCase
   def test_create_command
     # Define
     dsl = Cri::CommandDSL.new
-    dsl.instance_eval do 
+    dsl.instance_eval do
       name        'moo'
       usage       'dunno whatever'
       summary     'does stuff'
       description 'This command does a lot of stuff.'
 
-      option    :a, :aaa, 'opt a', :argument => :optional
+      option    :a, :aaa, 'opt a', :argument => :optional, :multiple => true
       required  :b, :bbb, 'opt b'
       optional  :c, :ccc, 'opt c'
       flag      :d, :ddd, 'opt d'
@@ -36,11 +36,11 @@ class Cri::CommandDSLTestCase < Cri::TestCase
 
     # Check options
     expected_option_definitions = Set.new([
-      { :short => 'a', :long => 'aaa', :desc => 'opt a', :argument => :optional,  :block => nil },
-      { :short => 'b', :long => 'bbb', :desc => 'opt b', :argument => :required,  :block => nil },
-      { :short => 'c', :long => 'ccc', :desc => 'opt c', :argument => :optional,  :block => nil },
-      { :short => 'd', :long => 'ddd', :desc => 'opt d', :argument => :forbidden, :block => nil },
-      { :short => 'e', :long => 'eee', :desc => 'opt e', :argument => :forbidden, :block => nil }
+      { :short => 'a', :long => 'aaa', :desc => 'opt a', :argument => :optional, :multiple => true,   :block => nil },
+      { :short => 'b', :long => 'bbb', :desc => 'opt b', :argument => :required, :multiple => false,  :block => nil },
+      { :short => 'c', :long => 'ccc', :desc => 'opt c', :argument => :optional, :multiple => false,  :block => nil },
+      { :short => 'd', :long => 'ddd', :desc => 'opt d', :argument => :forbidden, :multiple => false, :block => nil },
+      { :short => 'e', :long => 'eee', :desc => 'opt e', :argument => :forbidden, :multiple => false, :block => nil }
       ])
     actual_option_definitions = Set.new(command.option_definitions)
     assert_equal expected_option_definitions, actual_option_definitions

--- a/test/test_option_parser.rb
+++ b/test/test_option_parser.rb
@@ -279,4 +279,16 @@ class Cri::OptionParserTestCase < Cri::TestCase
     end
   end
 
+  def test_parse_with_multiple_options
+    input = %w( foo -o test -o test2 -v -v -v)
+    definitions = [
+      { :long => 'long', :short => 'o', :argument => :required, :multiple => true },
+      { :long => 'verbose', :short => 'v', :multiple => true }
+    ]
+    parser = Cri::OptionParser.parse(input, definitions)
+
+    assert_equal(['test', 'test2'], parser.options[:long])
+    assert_equal(3, parser.options[:verbose].size)
+  end
+
 end


### PR DESCRIPTION
This adds support for multiple arguments specified multiple times on the command line.

e.g.: command -o value1 -o value2 
