### PR TITLE
Update docs badge in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ link:http://rubygems.org/gems/cri[image:http://img.shields.io/gem/v/cri.svg[]]
 link:https://travis-ci.org/ddfreyne/cri[image:http://img.shields.io/travis/ddfreyne/cri.svg[]]
 link:https://coveralls.io/r/ddfreyne/cri[image:http://img.shields.io/coveralls/ddfreyne/cri.svg[]]
 link:https://codeclimate.com/github/ddfreyne/cri[image:http://img.shields.io/codeclimate/github/ddfreyne/cri.svg[]]
-link:http://inch-pages.github.io/github/ddfreyne/cri/[image:http://inch-pages.github.io/github/ddfreyne/cri.svg[]]
+link:http://inch-ci.org/github/ddfreyne/cri/[image:http://inch-ci.org/github/ddfreyne/cri.svg[]]
 
 Cri is a library for building easy-to-use commandline tools with support for
 nested commands.


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
