### PR TITLE
Fix option formatting

### DIFF
--- a/lib/cri/help_renderer.rb
+++ b/lib/cri/help_renderer.rb
@@ -111,9 +111,9 @@ module Cri
 
         case opt_def[:argument]
         when :required
-          string << '=value'
+          string << '=<value>'
         when :optional
-          string << '=[value]'
+          string << '=[<value>]'
         end
 
         string.size
@@ -146,19 +146,16 @@ module Cri
       end
     end
 
-    def raw_value_postfix_for(opt_def)
-      case opt_def[:argument]
-      when :required
-        'value'
-      when :optional
-        '[value]'
-      else
-        nil
-      end
-    end
-
     def short_value_postfix_for(opt_def)
-      value_postfix = raw_value_postfix_for(opt_def)
+      value_postfix =
+        case opt_def[:argument]
+        when :required
+          '<value>'
+        when :optional
+          '[<value>]'
+        else
+          nil
+        end
 
       if value_postfix
         opt_def[:long] ? '' : ' ' + value_postfix
@@ -168,10 +165,18 @@ module Cri
     end
 
     def long_value_postfix_for(opt_def)
-      value_postfix = raw_value_postfix_for(opt_def)
+      value_postfix =
+        case opt_def[:argument]
+        when :required
+          '=<value>'
+        when :optional
+          '[=<value>]'
+        else
+          nil
+        end
 
       if value_postfix
-        opt_def[:long] ? '=' + value_postfix : ''
+        opt_def[:long] ? value_postfix : ''
       else
         ''
       end

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -300,9 +300,9 @@ class Cri::CommandTestCase < Cri::TestCase
     end
     help = cmd.help
 
-    assert_match(/^    \e\[33m-r\e\[0m \e\[33m--required\e\[0m=value        required value$/, help)
-    assert_match(/^    \e\[33m-f\e\[0m \e\[33m--flag\e\[0m                  forbidden value$/, help)
-    assert_match(/^    \e\[33m-o\e\[0m \e\[33m--optional\e\[0m=\[value\]      optional value$/, help)
+    assert_match(/^    \e\[33m-r\e\[0m \e\[33m--required\e\[0m=<value>        required value$/, help)
+    assert_match(/^    \e\[33m-f\e\[0m \e\[33m--flag\e\[0m                    forbidden value$/, help)
+    assert_match(/^    \e\[33m-o\e\[0m \e\[33m--optional\e\[0m\[=<value>\]      optional value$/, help)
   end
 
   def test_help_with_different_option_types_short
@@ -316,9 +316,9 @@ class Cri::CommandTestCase < Cri::TestCase
     end
     help = cmd.help
 
-    assert_match(/^    \e\[33m-r\e\[0m value        required value$/, help)
-    assert_match(/^    \e\[33m-f\e\[0m              forbidden value$/, help)
-    assert_match(/^    \e\[33m-o\e\[0m \[value\]      optional value$/, help)
+    assert_match(/^    \e\[33m-r\e\[0m <value>        required value$/, help)
+    assert_match(/^    \e\[33m-f\e\[0m                forbidden value$/, help)
+    assert_match(/^    \e\[33m-o\e\[0m \[<value>\]      optional value$/, help)
   end
 
   def test_help_with_different_option_types_long
@@ -332,9 +332,9 @@ class Cri::CommandTestCase < Cri::TestCase
     end
     help = cmd.help
 
-    assert_match(/^       \e\[33m--required\e\[0m=value        required value$/, help)
-    assert_match(/^       \e\[33m--flag\e\[0m                  forbidden value$/, help)
-    assert_match(/^       \e\[33m--optional\e\[0m=\[value\]      optional value$/, help)
+    assert_match(/^       \e\[33m--required\e\[0m=<value>        required value$/, help)
+    assert_match(/^       \e\[33m--flag\e\[0m                    forbidden value$/, help)
+    assert_match(/^       \e\[33m--optional\e\[0m\[=<value>\]      optional value$/, help)
   end
 
   def test_help_with_multiple_groups


### PR DESCRIPTION
1. Option values are now enclosed in angle brackets.
2. The optional marker (`[` `]`) now includes the equal sign.

Before:

```
    -a value                lorem ipsum
    -b [value]              lorem ipsum
    -m --mithril=value      lorem ipsum
    -n --nori=[value]       lorem ipsum
```

After:

```
    -a <value>                lorem ipsum
    -b [<value>]              lorem ipsum
    -m --mithril=<value>      lorem ipsum
    -n --nori[=<value>]       lorem ipsum
```

CC @bmesuere