### PR TITLE
add support for hidden options

### DIFF
--- a/lib/cri/command_dsl.rb
+++ b/lib/cri/command_dsl.rb
@@ -104,10 +104,14 @@ module Cri
     # @option params [Boolean] :multiple Whether or not the option should
     #   be multi-valued
     #
+    # @option params [Boolean] :hidden Whether or not the option should
+    #   be printed in the help output
+    #
     # @return [void]
     def option(short, long, desc, params = {}, &block)
       requiredness = params.fetch(:argument, :forbidden)
       multiple = params.fetch(:multiple, false)
+      hidden = params.fetch(:hidden, false)
 
       if short.nil? && long.nil?
         fail ArgumentError, 'short and long options cannot both be nil'
@@ -120,6 +124,7 @@ module Cri
         :argument => requiredness,
         :multiple => multiple,
         :block    => block,
+        :hidden   => hidden,
       }
     end
     alias_method :opt, :option
@@ -135,6 +140,9 @@ module Cri
     #
     # @option params [Boolean] :multiple Whether or not the option should
     #   be multi-valued
+    #
+    # @option params [Boolean] :hidden Whether or not the option should
+    #   be printed in the help output
     #
     # @return [void]
     #
@@ -156,6 +164,9 @@ module Cri
     # @option params [Boolean] :multiple Whether or not the option should
     #   be multi-valued
     #
+    # @option params [Boolean] :hidden Whether or not the option should
+    #   be printed in the help output
+    #
     # @return [void]
     #
     # @see {#option}
@@ -176,6 +187,9 @@ module Cri
     #
     # @option params [Boolean] :multiple Whether or not the option should
     #   be multi-valued
+    #
+    # @option params [Boolean] :hidden Whether or not the option should
+    #   be printed in the help output
     #
     # @return [void]
     #

--- a/lib/cri/help_renderer.rb
+++ b/lib/cri/help_renderer.rb
@@ -141,8 +141,10 @@ module Cri
 
       ordered_defs = defs.sort_by { |x| x[:short] || x[:long] }
       ordered_defs.each do |opt_def|
-        text << format_opt_def(opt_def, length)
-        text << opt_def[:desc] << "\n"
+        unless opt_def[:hidden]
+          text << format_opt_def(opt_def, length)
+          text << opt_def[:desc] << "\n"
+        end
       end
     end
 

--- a/samples/sample_simple.rb
+++ b/samples/sample_simple.rb
@@ -18,6 +18,7 @@ EOS
   optional  :c,  :ccc,   'opt c'
   flag      :d,  :ddd,   'opt d'
   forbidden :e,  :eee,   'opt e'
+  flag      :f,  :fff,   'opt f', :hidden => true
   flag      :s,  nil,    'option with only a short form'
   flag      nil, 'long', 'option with only a long form'
 

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -16,6 +16,7 @@ module Cri
         optional  :c, :ccc, 'opt c'
         flag      :d, :ddd, 'opt d'
         forbidden :e, :eee, 'opt e'
+        flag      :f, :fff, 'opt f', :hidden => true
 
         run do |_opts, _args|
           $did_it_work = :probably
@@ -36,11 +37,12 @@ module Cri
 
       # Check options
       expected_option_definitions = Set.new([
-        { :short => 'a', :long => 'aaa', :desc => 'opt a', :argument => :optional, :multiple => true,   :block => nil },
-        { :short => 'b', :long => 'bbb', :desc => 'opt b', :argument => :required, :multiple => false,  :block => nil },
-        { :short => 'c', :long => 'ccc', :desc => 'opt c', :argument => :optional, :multiple => false,  :block => nil },
-        { :short => 'd', :long => 'ddd', :desc => 'opt d', :argument => :forbidden, :multiple => false, :block => nil },
-        { :short => 'e', :long => 'eee', :desc => 'opt e', :argument => :forbidden, :multiple => false, :block => nil },
+        { :short => 'a', :long => 'aaa', :desc => 'opt a', :argument => :optional,  :multiple => true,  :hidden => false, :block => nil },
+        { :short => 'b', :long => 'bbb', :desc => 'opt b', :argument => :required,  :multiple => false, :hidden => false, :block => nil },
+        { :short => 'c', :long => 'ccc', :desc => 'opt c', :argument => :optional,  :multiple => false, :hidden => false, :block => nil },
+        { :short => 'd', :long => 'ddd', :desc => 'opt d', :argument => :forbidden, :multiple => false, :hidden => false, :block => nil },
+        { :short => 'e', :long => 'eee', :desc => 'opt e', :argument => :forbidden, :multiple => false, :hidden => false, :block => nil },
+        { :short => 'f', :long => 'fff', :desc => 'opt f', :argument => :forbidden, :multiple => false, :hidden => true,  :block => nil },
       ])
       actual_option_definitions = Set.new(command.option_definitions)
       assert_equal expected_option_definitions, actual_option_definitions
@@ -71,8 +73,8 @@ module Cri
 
       # Check options
       expected_option_definitions = Set.new([
-        { :short => 's', :long => nil,    :desc => 'short', :argument => :forbidden, :multiple => false, :block => nil },
-        { :short => nil, :long => 'long', :desc => 'long',  :argument => :forbidden, :multiple => false, :block => nil },
+        { :short => 's', :long => nil,    :desc => 'short', :argument => :forbidden, :multiple => false, :hidden => false, :block => nil },
+        { :short => nil, :long => 'long', :desc => 'long',  :argument => :forbidden, :multiple => false, :hidden => false, :block => nil },
       ])
       actual_option_definitions = Set.new(command.option_definitions)
       assert_equal expected_option_definitions, actual_option_definitions
@@ -82,9 +84,9 @@ module Cri
       # Define
       dsl = Cri::CommandDSL.new
       dsl.instance_eval do
-        flag     :f, :flag,     'sample flag option',     :multiple => true
-        required :r, :required, 'sample required option', :multiple => true
-        optional :o, :optional, 'sample optional option', :multiple => true
+        flag     :f, :flag,     'flag', :multiple => true
+        required :r, :required, 'req',  :multiple => true
+        optional :o, :optional, 'opt',  :multiple => true
 
         run { |_opts, _args| }
       end
@@ -92,9 +94,31 @@ module Cri
 
       # Check options
       expected_option_definitions = Set.new([
-        { :short => 'f', :long => 'flag',     :desc => 'sample flag option',     :argument => :forbidden, :multiple => true, :block => nil },
-        { :short => 'r', :long => 'required', :desc => 'sample required option', :argument => :required,  :multiple => true, :block => nil },
-        { :short => 'o', :long => 'optional', :desc => 'sample optional option', :argument => :optional,  :multiple => true, :block => nil },
+        { :short => 'f', :long => 'flag',     :desc => 'flag', :argument => :forbidden, :multiple => true, :hidden => false, :block => nil },
+        { :short => 'r', :long => 'required', :desc => 'req',  :argument => :required,  :multiple => true, :hidden => false, :block => nil },
+        { :short => 'o', :long => 'optional', :desc => 'opt',  :argument => :optional,  :multiple => true, :hidden => false, :block => nil },
+      ])
+      actual_option_definitions = Set.new(command.option_definitions)
+      assert_equal expected_option_definitions, actual_option_definitions
+    end
+
+    def test_hidden
+      # Define
+      dsl = Cri::CommandDSL.new
+      dsl.instance_eval do
+        flag     :f, :flag,     'flag', :hidden => true
+        required :r, :required, 'req',  :hidden => true
+        optional :o, :optional, 'opt',  :hidden => true
+
+        run { |_opts, _args| }
+      end
+      command = dsl.command
+
+      # Check options
+      expected_option_definitions = Set.new([
+        { :short => 'f', :long => 'flag',     :desc => 'flag', :argument => :forbidden, :multiple => false, :hidden => true, :block => nil },
+        { :short => 'r', :long => 'required', :desc => 'req',  :argument => :required,  :multiple => false, :hidden => true, :block => nil },
+        { :short => 'o', :long => 'optional', :desc => 'opt',  :argument => :optional,  :multiple => false, :hidden => true, :block => nil },
       ])
       actual_option_definitions = Set.new(command.option_definitions)
       assert_equal expected_option_definitions, actual_option_definitions


### PR DESCRIPTION
This adds support for hidden options. When an option is created with `:hidden => true`, it won't show up in the generated help.