### PR TITLE
Line wrap the option descriptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,7 @@ Style/GlobalVars:
 Metrics/AbcSize:
   Max: 45
 Metrics/ClassLength:
+  Enabled: false
   Max: 436
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/lib/cri/help_renderer.rb
+++ b/lib/cri/help_renderer.rb
@@ -4,6 +4,15 @@ module Cri
   # The {HelpRenderer} class is responsible for generating a string containing
   # the help for a given command, intended to be printed on the command line.
   class HelpRenderer
+    # The line width of the help output
+    LINE_WIDTH = 78
+
+    # The indentation of descriptions
+    DESC_INDENT = 4
+
+    # The spacing between an option name and option description
+    OPT_DESC_SPACING = 6
+
     # Creates a new help renderer for the given command.
     #
     # @param [Cri::Command] cmd The command to generate the help for
@@ -55,7 +64,7 @@ module Cri
 
       text << "\n"
       text << fmt.format_as_title('usage', @io) << "\n"
-      text << fmt.wrap_and_indent(full_usage, 78, 4) << "\n"
+      text << fmt.wrap_and_indent(full_usage, LINE_WIDTH, DESC_INDENT) << "\n"
     end
 
     def append_description(text)
@@ -63,7 +72,7 @@ module Cri
 
       text << "\n"
       text << fmt.format_as_title('description', @io) << "\n"
-      text << fmt.wrap_and_indent(@cmd.description, 78, 4) + "\n"
+      text << fmt.wrap_and_indent(@cmd.description, LINE_WIDTH, DESC_INDENT) + "\n"
     end
 
     def append_subcommands(text)
@@ -80,7 +89,7 @@ module Cri
       shown_subcommands.sort_by { |cmd| cmd.name }.each do |cmd|
         text <<
           format(
-            "    %-#{length + 4}s %s\n",
+            "    %-#{length + DESC_INDENT}s %s\n",
             fmt.format_as_command(cmd.name, @io),
             cmd.summary)
       end
@@ -143,7 +152,7 @@ module Cri
       ordered_defs.each do |opt_def|
         unless opt_def[:hidden]
           text << format_opt_def(opt_def, length)
-          text << fmt.wrap_and_indent(opt_def[:desc], 78, length + 10, true) << "\n"
+          text << fmt.wrap_and_indent(opt_def[:desc], LINE_WIDTH, length + OPT_DESC_SPACING + DESC_INDENT, true) << "\n"
         end
       end
     end
@@ -204,7 +213,7 @@ module Cri
       opt_text_len += 2 + opt_def[:long].size if opt_def[:long]
       opt_text_len += long_value_postfix.size
 
-      '    ' + opt_text + ' ' * (length + 6 - opt_text_len)
+      '    ' + opt_text + ' ' * (length + OPT_DESC_SPACING - opt_text_len)
     end
   end
 end

--- a/lib/cri/help_renderer.rb
+++ b/lib/cri/help_renderer.rb
@@ -143,7 +143,7 @@ module Cri
       ordered_defs.each do |opt_def|
         unless opt_def[:hidden]
           text << format_opt_def(opt_def, length)
-          text << opt_def[:desc] << "\n"
+          text << fmt.wrap_and_indent(opt_def[:desc], 78, length + 10, true) << "\n"
         end
       end
     end

--- a/lib/cri/string_formatter.rb
+++ b/lib/cri/string_formatter.rb
@@ -34,15 +34,18 @@ module Cri
     #
     # @param [Number] indentation The number of spaces to indent each line.
     #
+    # @param [Boolean] first_line_already_indented Whether or not the first
+    #   line is already indented
+    #
     # @return [String] The word-wrapped and indented string
-    def wrap_and_indent(s, width, indentation)
+    def wrap_and_indent(s, width, indentation, first_line_already_indented = false)
       indented_width = width - indentation
       indent = ' ' * indentation
       # Split into paragraphs
       paragraphs = to_paragraphs(s)
 
       # Wrap and indent each paragraph
-      paragraphs.map do |paragraph|
+      text = paragraphs.map do |paragraph|
         # Initialize
         lines = []
         line = ''
@@ -63,6 +66,12 @@ module Cri
         # Join lines
         lines.map { |l| indent + l }.join("\n")
       end.join("\n\n")
+
+      if first_line_already_indented
+        text[indentation..-1]
+      else
+        text
+      end
     end
 
     # @param [String] s The string to format

--- a/samples/sample_simple.rb
+++ b/samples/sample_simple.rb
@@ -19,6 +19,7 @@ EOS
   flag      :d,  :ddd,   'opt d'
   forbidden :e,  :eee,   'opt e'
   flag      :f,  :fff,   'opt f', :hidden => true
+  flag      :g,  :ggg,   'this is an option with a very long description that should reflow nicely'
   flag      :s,  nil,    'option with only a short form'
   flag      nil, 'long', 'option with only a long form'
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -370,6 +370,21 @@ module Cri
       assert_equal 'compile', cmd.name
     end
 
+    def test_help_with_wrapped_options
+      def $stdout.tty?
+        true
+      end
+
+      cmd = Cri::Command.define do
+        name 'build'
+        flag     nil, :longflag,     'This is an option with a very long description that should be wrapped'
+      end
+      help = cmd.help
+
+      assert_match(/^       \e\[33m--longflag\e\[0m      This is an option with a very long description that$/, help)
+      assert_match(/^                       should be wrapped$/, help)
+    end
+
     def test_modify_without_block_argument
       cmd = Cri::Command.define do
         name 'build'

--- a/test/test_string_formatter.rb
+++ b/test/test_string_formatter.rb
@@ -46,6 +46,21 @@ module Cri
       assert_equal expected, actual
     end
 
+    def test_string_wrap_and_indent_excluding_first_line
+      original = 'Lorem ipsum dolor sit amet, consectetur adipisicing ' \
+                 'elit, sed do eiusmod tempor incididunt ut labore et dolore ' \
+                 'magna aliqua.'
+
+      expected = "Lorem ipsum dolor sit amet,\n" \
+                 "    consectetur adipisicing elit,\n" \
+                 "    sed do eiusmod tempor\n" \
+                 "    incididunt ut labore et dolore\n" \
+                 '    magna aliqua.'
+
+      actual = formatter.wrap_and_indent(original, 36, 4, true)
+      assert_equal expected, actual
+    end
+
     def test_string_wrap_and_indent_with_large_indent
       original = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, ' \
                  'sed do eiusmod tempor incididunt ut labore et dolore ' \


### PR DESCRIPTION
This enables wrapping the option description and fixes #36.
I'm not quite sure if this is the right approach to fixing this, so I'm waiting on approval to add tests.
