### PR TITLE
Add hard_exit param

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,11 +64,11 @@ Metrics/ClassLength:
   Enabled: false
   Max: 436
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Max: 9
 Metrics/LineLength:
   Enabled: false
   Max: 141
 Metrics/MethodLength:
   Max: 41
 Metrics/PerceivedComplexity:
-  Max: 9
+  Max: 10

--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -38,7 +38,7 @@ module Cri
       end
     end
 
-    # Signals that Cri should abort execution. Unless otherwise specified using the `exit_on_error`
+    # Signals that Cri should abort execution. Unless otherwise specified using the `hard_exit`
     # param, this exception will cause Cri to exit the running process.
     #
     # @api private
@@ -225,7 +225,7 @@ module Cri
     # @param [String] name The full, partial or aliases name of the command
     #
     # @return [Cri::Command] The command with the given name
-    def command_named(name, exit_on_error: true)
+    def command_named(name, hard_exit: true)
       commands = commands_named(name)
 
       if commands.empty?
@@ -239,7 +239,7 @@ module Cri
         commands[0]
       end
     rescue CriExitException => e
-      exit(e.error? ? 1 : 0) if exit_on_error
+      exit(e.error? ? 1 : 0) if hard_exit
     end
 
     # Runs the command with the given command-line arguments, possibly invoking
@@ -251,7 +251,7 @@ module Cri
     #   supercommand
     #
     # @return [void]
-    def run(opts_and_args, parent_opts = {}, exit_on_error: true)
+    def run(opts_and_args, parent_opts = {}, hard_exit: true)
       # Parse up to command name
       stuff = partition(opts_and_args)
       opts_before_subcmd, subcmd_name, opts_and_args_after_subcmd = *stuff
@@ -267,14 +267,14 @@ module Cri
           $stderr.puts "#{name}: no command given"
           raise CriExitException.new(is_error: true)
         end
-        subcommand = command_named(subcmd_name, exit_on_error: exit_on_error)
+        subcommand = command_named(subcmd_name, hard_exit: hard_exit)
         return if subcommand.nil?
 
         # Run
-        subcommand.run(opts_and_args_after_subcmd, opts_before_subcmd, exit_on_error: exit_on_error)
+        subcommand.run(opts_and_args_after_subcmd, opts_before_subcmd, hard_exit: hard_exit)
       end
     rescue CriExitException => e
-      exit(e.error? ? 1 : 0) if exit_on_error
+      exit(e.error? ? 1 : 0) if hard_exit
     end
 
     # Runs the actual command with the given command-line arguments, not

--- a/lib/cri/commands/basic_root.rb
+++ b/lib/cri/commands/basic_root.rb
@@ -1,6 +1,6 @@
 flag :h, :help, 'show help for this command' do |_value, cmd|
   puts cmd.help
-  exit 0
+  raise CriExitException.new(is_error: false)
 end
 
 subcommand Cri::Command.new_basic_help

--- a/test/test_basic_root.rb
+++ b/test/test_basic_root.rb
@@ -17,7 +17,7 @@ module Cri
       cmd = Cri::Command.new_basic_root
 
       stdout, _stderr = capture_io_while do
-        cmd.run(%w(-h), {}, exit_on_error: false)
+        cmd.run(%w(-h), {}, hard_exit: false)
       end
 
       assert stdout =~ /COMMANDS.*\n.*help.*show help/

--- a/test/test_basic_root.rb
+++ b/test/test_basic_root.rb
@@ -4,9 +4,20 @@ module Cri
       cmd = Cri::Command.new_basic_root
 
       stdout, _stderr = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           cmd.run(%w(-h))
         end
+        assert_equal 0, err.status
+      end
+
+      assert stdout =~ /COMMANDS.*\n.*help.*show help/
+    end
+
+    def test_run_with_help_no_exit
+      cmd = Cri::Command.new_basic_root
+
+      stdout, _stderr = capture_io_while do
+        cmd.run(%w(-h), {}, exit_on_error: false)
       end
 
       assert stdout =~ /COMMANDS.*\n.*help.*show help/

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -157,7 +157,7 @@ module Cri
 
     def test_invoke_simple_with_missing_opt_arg_no_exit
       out, err = capture_io_while do
-        simple_cmd.run(%w(-b), {}, exit_on_error: false)
+        simple_cmd.run(%w(-b), {}, hard_exit: false)
       end
 
       assert_equal [], lines(out)
@@ -178,7 +178,7 @@ module Cri
 
     def test_invoke_simple_with_illegal_opt_no_exit
       out, err = capture_io_while do
-        simple_cmd.run(%w(-z), {}, exit_on_error: false)
+        simple_cmd.run(%w(-z), {}, hard_exit: false)
       end
 
       assert_equal [], lines(out)
@@ -208,7 +208,7 @@ module Cri
 
     def test_invoke_nested_without_opts_or_args_no_exit
       out, err = capture_io_while do
-        nested_cmd.run(%w(), {}, exit_on_error: false)
+        nested_cmd.run(%w(), {}, hard_exit: false)
       end
 
       assert_equal [], lines(out)
@@ -238,7 +238,7 @@ module Cri
 
     def test_invoke_nested_with_incorrect_command_name_no_exit
       out, err = capture_io_while do
-        nested_cmd.run(%w(oogabooga), {}, exit_on_error: false)
+        nested_cmd.run(%w(oogabooga), {}, hard_exit: false)
       end
 
       assert_equal [], lines(out)
@@ -259,7 +259,7 @@ module Cri
 
     def test_invoke_nested_with_ambiguous_command_name_no_exit
       out, err = capture_io_while do
-        nested_cmd.run(%w(s), {}, exit_on_error: false)
+        nested_cmd.run(%w(s), {}, hard_exit: false)
       end
 
       assert_equal [], lines(out)

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -145,9 +145,19 @@ module Cri
 
     def test_invoke_simple_with_missing_opt_arg
       out, err = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           simple_cmd.run(%w(-b))
         end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['moo: option requires an argument -- b'], lines(err)
+    end
+
+    def test_invoke_simple_with_missing_opt_arg_no_exit
+      out, err = capture_io_while do
+        simple_cmd.run(%w(-b), {}, exit_on_error: false)
       end
 
       assert_equal [], lines(out)
@@ -156,9 +166,19 @@ module Cri
 
     def test_invoke_simple_with_illegal_opt
       out, err = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           simple_cmd.run(%w(-z))
         end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['moo: illegal option -- z'], lines(err)
+    end
+
+    def test_invoke_simple_with_illegal_opt_no_exit
+      out, err = capture_io_while do
+        simple_cmd.run(%w(-z), {}, exit_on_error: false)
       end
 
       assert_equal [], lines(out)
@@ -176,9 +196,19 @@ module Cri
 
     def test_invoke_nested_without_opts_or_args
       out, err = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           nested_cmd.run(%w())
         end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['super: no command given'], lines(err)
+    end
+
+    def test_invoke_nested_without_opts_or_args_no_exit
+      out, err = capture_io_while do
+        nested_cmd.run(%w(), {}, exit_on_error: false)
       end
 
       assert_equal [], lines(out)
@@ -196,9 +226,19 @@ module Cri
 
     def test_invoke_nested_with_incorrect_command_name
       out, err = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           nested_cmd.run(%w(oogabooga))
         end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ["super: unknown command 'oogabooga'"], lines(err)
+    end
+
+    def test_invoke_nested_with_incorrect_command_name_no_exit
+      out, err = capture_io_while do
+        nested_cmd.run(%w(oogabooga), {}, exit_on_error: false)
       end
 
       assert_equal [], lines(out)
@@ -207,9 +247,19 @@ module Cri
 
     def test_invoke_nested_with_ambiguous_command_name
       out, err = capture_io_while do
-        assert_raises SystemExit do
+        err = assert_raises SystemExit do
           nested_cmd.run(%w(s))
         end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ["super: 's' is ambiguous:", '  sink sub'], lines(err)
+    end
+
+    def test_invoke_nested_with_ambiguous_command_name_no_exit
+      out, err = capture_io_while do
+        nested_cmd.run(%w(s), {}, exit_on_error: false)
       end
 
       assert_equal [], lines(out)


### PR DESCRIPTION
When passing `hard_exit: false` to `#run` and `#command_named`, Cri will return rather than exit. The default is `true` (exit rather than return).

Example:

```ruby
command = …
command.run(args, {}, hard_exit: false)
```

Unfortunately, the icky extra `{}` has to be retained for backwards compatibility.

Fixes #49.
Fixes #50.