### PR TITLE
Support specifying values for combined options

### DIFF
--- a/lib/cri/option_parser.rb
+++ b/lib/cri/option_parser.rb
@@ -223,10 +223,7 @@ module Cri
         definition = @definitions.find { |d| d[:short] == option_key }
         raise IllegalOptionError.new(option_key) if definition.nil?
 
-        if option_keys.length > 1 && definition[:argument] == :required
-          # This is a combined option and it requires an argument, so complain
-          raise OptionRequiresAnArgumentError.new(option_key)
-        elsif %i[required optional].include?(definition[:argument])
+        if %i[required optional].include?(definition[:argument])
           # Get option value
           option_value = find_option_value(definition, option_key)
 

--- a/test/test_option_parser.rb
+++ b/test/test_option_parser.rb
@@ -171,16 +171,19 @@ module Cri
     end
 
     def test_parse_with_short_combined_valueful_options_with_missing_value
-      input       = %w[foo -abc bar]
+      input       = %w[foo -abc bar qux]
       definitions = [
         { long: 'aaa', short: 'a', argument: :required  },
         { long: 'bbb', short: 'b', argument: :forbidden },
         { long: 'ccc', short: 'c', argument: :forbidden },
       ]
 
-      assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.parse(input, definitions)
-      end
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal('bar', parser.options[:aaa])
+      assert(parser.options[:bbb])
+      assert(parser.options[:ccc])
+      assert_equal(%w[foo qux], parser.arguments)
     end
 
     def test_parse_with_two_short_valueful_options
@@ -336,6 +339,48 @@ module Cri
 
       assert_equal({ animal: 'gi' }, parser.options)
       assert_equal(%w[foo raffe], parser.arguments)
+    end
+
+    def test_parse_with_combined_required_options
+      input       = %w[foo -abc xxx yyy zzz]
+      definitions = [
+        { long: 'aaa', short: 'a', argument: :forbidden },
+        { long: 'bbb', short: 'b', argument: :required },
+        { long: 'ccc', short: 'c', argument: :required },
+      ]
+
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal({ aaa: true, bbb: 'xxx', ccc: 'yyy' }, parser.options)
+      assert_equal(%w[foo zzz], parser.arguments)
+    end
+
+    def test_parse_with_combined_optional_options
+      input       = %w[foo -abc xxx yyy zzz]
+      definitions = [
+        { long: 'aaa', short: 'a', argument: :forbidden },
+        { long: 'bbb', short: 'b', argument: :optional },
+        { long: 'ccc', short: 'c', argument: :required },
+      ]
+
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal({ aaa: true, bbb: 'xxx', ccc: 'yyy' }, parser.options)
+      assert_equal(%w[foo zzz], parser.arguments)
+    end
+
+    def test_parse_with_combined_optional_options_with_missing_value
+      input       = %w[foo -abc xxx]
+      definitions = [
+        { long: 'aaa', short: 'a', argument: :forbidden },
+        { long: 'bbb', short: 'b', argument: :required },
+        { long: 'ccc', short: 'c', argument: :optional, default: 'c default' },
+      ]
+
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal({ aaa: true, bbb: 'xxx', ccc: 'c default' }, parser.options)
+      assert_equal(%w[foo], parser.arguments)
     end
   end
 end


### PR DESCRIPTION
Fixes #46.

This allows specifying short options in a combined way, e.g.

```
foo -abc xxx yyy
```

… even when some of these options have a required or optional value. In the example above, if `b` and `c` have required or optional values, the result is

``` ruby
{
  aaa: true,
  bbb: 'xxx',
  ccc: 'yyy',
}
```