### PR TITLE
Always set default option values if present

### DIFF
--- a/lib/cri/command_dsl.rb
+++ b/lib/cri/command_dsl.rb
@@ -127,8 +127,8 @@ module Cri
         raise ArgumentError, 'short and long options cannot both be nil'
       end
 
-      if default && requiredness != :optional
-        raise ArgumentError, "a default value cannot be specified for options with #{requiredness} values"
+      if default && requiredness == :forbidden
+        raise ArgumentError, 'a default value cannot be specified for flag options'
       end
 
       @command.option_definitions << {

--- a/lib/cri/option_parser.rb
+++ b/lib/cri/option_parser.rb
@@ -173,12 +173,19 @@ module Cri
           add_argument(e)
         end
       end
+
+      add_defaults
+
       self
     ensure
       @running = false
     end
 
     private
+
+    def add_defaults
+      @definitions.each { |d| add_default_option(d) }
+    end
 
     def handle_dashdash(e)
       add_argument(e)
@@ -252,7 +259,8 @@ module Cri
     end
 
     def add_option(definition, value)
-      key = (definition[:long] || definition[:short]).to_sym
+      key = key_for(definition)
+
       if definition[:multiple]
         options[key] ||= []
         options[key] << value
@@ -261,6 +269,25 @@ module Cri
       end
 
       delegate.option_added(key, value, self) unless delegate.nil?
+    end
+
+    def add_default_option(definition)
+      key = key_for(definition)
+      return if options.key?(key)
+
+      value = definition[:default]
+      return unless value
+
+      if definition[:multiple]
+        options[key] ||= []
+        options[key] << value
+      else
+        options[key] = value
+      end
+    end
+
+    def key_for(definition)
+      (definition[:long] || definition[:short]).to_sym
     end
 
     def add_argument(value)

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -161,15 +161,12 @@ module Cri
       end
     end
 
-    def test_default_value_errors_when_requiredness_is_required
+    def test_default_value_with_equiredness_is_required
       dsl = Cri::CommandDSL.new
 
-      err = assert_raises ArgumentError do
-        dsl.instance_eval do
-          required 'a', 'animal', 'Specify animal', default: 'giraffe'
-        end
+      dsl.instance_eval do
+        required 'a', 'animal', 'Specify animal', default: 'giraffe'
       end
-      assert_equal('a default value cannot be specified for options with required values', err.message)
     end
 
     def test_default_value_errors_when_requiredness_is_forbidden
@@ -180,7 +177,7 @@ module Cri
           flag 'a', 'animal', 'Allow animal', default: 'giraffe'
         end
       end
-      assert_equal('a default value cannot be specified for options with forbidden values', err.message)
+      assert_equal('a default value cannot be specified for flag options', err.message)
     end
 
     def test_subcommand

--- a/test/test_option_parser.rb
+++ b/test/test_option_parser.rb
@@ -282,6 +282,18 @@ module Cri
       assert_equal(3, parser.options[:verbose].size)
     end
 
+    def test_parse_with_default_required_unspecified
+      input       = %w[foo]
+      definitions = [
+        { long: 'animal', short: 'a', argument: :required, default: 'donkey' },
+      ]
+
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal({ animal: 'donkey' }, parser.options)
+      assert_equal(['foo'], parser.arguments)
+    end
+
     def test_parse_with_default_required_no_value
       input       = %w[foo -a]
       definitions = [
@@ -302,6 +314,18 @@ module Cri
       parser = Cri::OptionParser.parse(input, definitions)
 
       assert_equal({ animal: 'giraffe' }, parser.options)
+      assert_equal(['foo'], parser.arguments)
+    end
+
+    def test_parse_with_default_optional_unspecified
+      input       = %w[foo]
+      definitions = [
+        { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
+      ]
+
+      parser = Cri::OptionParser.parse(input, definitions)
+
+      assert_equal({ animal: 'donkey' }, parser.options)
       assert_equal(['foo'], parser.arguments)
     end
 


### PR DESCRIPTION
Fixes #57.

This makes Cri always return a hash with the default values, if any.

For example, given a command with the following option definitions:

```ruby
[
  { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
]
```

If this command is invoked without arguments, then the returned option values will be `{ animal: 'donkey' }` rather than `{}`.

This works for both optional and required options, but not for forbidden/flag options.