### PR TITLE
Fix syntax error in command.rb

### DIFF
--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -43,7 +43,7 @@ module Cri
     #
     # @api private
     class CriExitException < StandardError
-      def initialize(is_error:)
+      def initialize(is_error)
         @is_error = is_error
       end
 


### PR DESCRIPTION
Remove extranous colon. This fixes #60.