### PR TITLE
Add support to skip option parsing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -174,6 +174,33 @@ this example). The option definition would then look like this:
 flag :v, :verbose, 'be verbose (use up to three times)', multiple: true
 --------------------------------------------------------------------------------
 
+==== Skipping option parsing ====
+
+If you want to skip option parsing for your command or subcommand, you can add
+the `skip_option_parsing` method to your command definition and everything on your
+command line after the command name will be passed to your command as arguments.
+
+[source,ruby]
+-------------------------------------------------------------------------------
+command = Cri::Command.define do
+  name        'dostuff'
+  usage       'dostuff [args]'
+  aliases     :ds, :stuff
+  summary     'does stuff'
+  description 'This command does a lot of stuff, but not option parsing.'
+
+  skip_option_parsing
+
+  run do |opts, args, cmd|
+    puts args.inspect
+  end
+end
+-------------------------------------------------------------------------------
+
+When executing this command with `dostuff --some=value -f yes`, the `opts` hash
+that is passed to your `run` block will be empty and the `args` array will be
+`["--some=value", "-f", "yes"]`.
+
 === The run block ===
 
 The last part of the command defines the execution itself:

--- a/lib/cri/command_dsl.rb
+++ b/lib/cri/command_dsl.rb
@@ -98,6 +98,14 @@ module Cri
       @command.hidden = true
     end
 
+    # Skips option parsing for the command. Allows option-like arguments to be
+    # passed in, avoiding the {Cri::OptionParser} validation.
+    #
+    # @return [void]
+    def skip_option_parsing
+      @command.all_opts_as_args = true
+    end
+
     # Adds a new option to the command. If a block is given, it will be
     # executed when the option is successfully parsed.
     #

--- a/samples/sample_capture_opts_as_args.rb
+++ b/samples/sample_capture_opts_as_args.rb
@@ -1,0 +1,34 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
+require 'cri'
+
+super_cmd = Cri::Command.define do
+  name        'super'
+  usage       'does something super'
+  summary     'does super stuff'
+  description 'This command does super stuff.'
+
+  option    :a, :aaa, 'opt a', argument: :optional
+  required  :b, :bbb, 'opt b'
+  flag      :d, :ddd, 'opt d'
+  optional  :c, :ccc, 'opt c'
+  forbidden :e, :eee, 'opt e'
+end
+
+super_cmd.define_command do
+  name        'sub'
+  usage       'does something subby'
+  summary     'does subby stuff'
+  description 'This command does subby stuff.'
+  skip_option_parsing
+
+  run do |opts, args|
+    $stdout.puts 'in subcommand'
+
+    $stdout.puts "arguments: #{args.inspect}"
+    $stdout.puts "options:   #{opts.inspect}"
+  end
+end
+
+super_cmd.add_command Cri::Command.new_basic_help
+
+super_cmd.run(ARGV)

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -632,5 +632,46 @@ module Cri
       end
       assert_equal "I am the subcommand!\n", out
     end
+
+    def test_skip_option_parsing
+      command = Cri::Command.define do
+        name 'super'
+        skip_option_parsing
+
+        run do |_opts, args, _c|
+          puts "args=#{args.join(',')}"
+        end
+      end
+
+      out, _err = capture_io_while do
+        command.run(['--test', '-a', 'arg'])
+      end
+
+      assert_equal "args=--test,-a,arg\n", out
+    end
+
+    def test_subcommand_skip_option_parsing
+      super_cmd = Cri::Command.define do
+        name 'super'
+
+        option :a, :aaa, 'opt a', argument: :optional
+      end
+
+      super_cmd.define_command do
+        name 'sub'
+
+        skip_option_parsing
+
+        run do |opts, args, _c|
+          puts "opts=#{opts.inspect} args=#{args.join(',')}"
+        end
+      end
+
+      out, _err = capture_io_while do
+        super_cmd.run(['--aaa', 'test', 'sub', '--test', 'value'])
+      end
+
+      assert_equal "opts={:aaa=>\"test\"} args=--test,value\n", out
+    end
   end
 end


### PR DESCRIPTION
When defining a command that takes arguments that look like options, it
would be nice to have a simple way to skip the option parsing logic and
just return all the arguments. This can currently be worked around with
the positional separator `--`, but this isn't a great experience when
you have to have that as the first argument every time.

This PR introduces the `skip_option_parsing!` method to the command DSL
which turns off the option parsing for that command.