### PR TITLE
clarified some things about defining options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -111,15 +111,15 @@ option :s,  :stuff, 'specify stuff to do', argument: :required
 
 Options can be defined using the following methods:
 
-* `Cri::CommandDSL#option` or `Cri::CommandDSL#opt`
+* `Cri::CommandDSL#option` or `Cri::CommandDSL#opt` (include an `argument` parameter: `:required` or `:optional` that specifies if the option requires or allows an argument)
 * `Cri::CommandDSL#flag` (implies no arguments passed to option)
-* `Cri::CommandDSL#required` (implies required argument)
-* `Cri::CommandDSL#optional` (implies optional argument)
+* `Cri::CommandDSL#required` (implies an option that requires an argument)
+* `Cri::CommandDSL#optional` (implies an option that can optionally include an argument)
 
 All these methods take these arguments:
 
-1. a short option
-2. a long option
+1. a short option name
+2. a long option name
 3. a description
 4. optional extra parameters
 
@@ -128,12 +128,12 @@ would not make any sense). In the example above, the `--more` option has no
 short form.
 
 Each of the above methods also take a block, which will be executed when the
-option is found. The argument to the block are the option value (`true` in
+option is found. The arguments to the block are the option value (`true` in
 case the option does not have an argument) and the command.
 
 ==== Options with default values ====
 
-The `:default` parameter sets the option value that will be used if no explicit value is provided:
+The `:default` parameter sets the option value that will be used if the option is passed without an argument or isn't passed at all:
 
 [source,ruby]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This one's a bit longer. Feel free to edit some changes if you like the idea but not the details :)

I was initially confused about a few things regarding the options, so I thought it would make sense to make it clearer in the readme how they work.

1) I understood at first that the most basic form of an option is: `option :n, :name, 'desc'`, that's how it intuitively makes sense to me. However, it turns out this actually creates a flag, because you need to pass the `argument:` parameter, which, surprisingly, defaults to `:forbidden`. Ideally I think this should default to `:optional`, so that you could use this simplest form by default and then add options if you want to customize it, but that would be a breaking API change, so a readme edit will have to do. So I added an explanation to the `#option` point that you really should pass that parameter there in most cases.

2) I also initially understood that "required" or "optional" is about the *option* itself being required, somehow it didn't even occur to me that it could be just about the argument... So I made all my options optional at first, because I don't require them to be passed. I only started digging into this once I noticed the square brackets in `--option=[<value>]` in the help, and I realized that changing an option to required removes those brackets, but that the command somehow still works if I don't pass it. So I changed the language a bit where the options are described to make it clear it's about whether the option requires an argument or not.

3) Related to 2 - after realizing how this works, I thought that "if no explicit value is provided" means that this only relates to the case when the option is passed but without an argument, but apparently the default is also set if the option isn't passed at all, so I also mentioned that explicitly.
