### PR TITLE
Allow transforming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,42 @@ Each of the above methods also take a block, which will be executed when the
 option is found. The arguments to the block are the option value (`true` in
 case the option does not have an argument) and the command.
 
+#### Transforming options
+
+The `:transform` parameter specifies how the value should be transformed. It takes any object that responds to `#call`:
+
+```ruby
+option :p, :port, 'set port', argument: :required,
+  transform: -> (x) { Integer(x) }
+```
+
+The following example uses `#Integer` to transform a string into an integer:
+
+```ruby
+option :p, :port, 'set port', argument: :required, transform: method(:Integer)
+```
+
+The following example uses a custom object to perform transformation, as well as validation:
+
+```ruby
+class PortTransformer
+  def call(str)
+    raise ArgumentError unless str.is_a?(String)
+    Integer(str).tap do |int|
+      raise unless (0x0001..0xffff).include?(int)
+    end
+  end
+end
+
+option :p, :port, 'set port', argument: :required, transform: PortTransformer.new
+```
+
+Default values are not transformed:
+
+```ruby
+option :p, :port, 'set port', argument: :required, default: 8080, transform: PortTransformer.new
+```
+
 #### Options with default values
 
 The `:default` parameter sets the option value that will be used if the option is passed without an argument or isn't passed at all:

--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -388,6 +388,9 @@ module Cri
     rescue Cri::OptionParser::OptionRequiresAnArgumentError => e
       warn "#{name}: option requires an argument -- #{e}"
       raise CriExitException.new(is_error: true)
+    rescue Cri::OptionParser::IllegalOptionValueError => e
+      warn "#{name}: #{e.message}"
+      raise CriExitException.new(is_error: true)
     end
   end
 end

--- a/lib/cri/command_dsl.rb
+++ b/lib/cri/command_dsl.rb
@@ -132,6 +132,7 @@ module Cri
       multiple = params.fetch(:multiple, false)
       hidden = params.fetch(:hidden, false)
       default = params.fetch(:default, nil)
+      transform = params.fetch(:transform, nil)
 
       if short.nil? && long.nil?
         raise ArgumentError, 'short and long options cannot both be nil'
@@ -150,6 +151,7 @@ module Cri
         block: block,
         hidden: hidden,
         default: default,
+        transform: transform,
       }
     end
     alias opt option

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -18,6 +18,7 @@ module Cri
         optional  :c, :ccc, 'opt c'
         flag      :d, :ddd, 'opt d'
         forbidden :e, :eee, 'opt e'
+        required  :t, :transform, 'opt t', transform: method(:Integer)
 
         run do |opts, args, c|
           $stdout.puts "Awesome #{c.name}!"
@@ -187,6 +188,27 @@ module Cri
 
       assert_equal [], lines(out)
       assert_equal ['moo: unrecognised option -- z'], lines(err)
+    end
+
+    def test_invoke_simple_with_invalid_value_for_opt
+      out, err = capture_io_while do
+        err = assert_raises SystemExit do
+          simple_cmd.run(%w[-t nope])
+        end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['moo: invalid value "nope" for --transform option'], lines(err)
+    end
+
+    def test_invoke_simple_with_invalid_value_for_opt_no_exit
+      out, err = capture_io_while do
+        simple_cmd.run(%w[-t nope], {}, hard_exit: false)
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['moo: invalid value "nope" for --transform option'], lines(err)
     end
 
     def test_invoke_simple_with_opt_with_block

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -41,12 +41,12 @@ module Cri
       expected_option_definitions =
         Set.new(
           [
-            { short: 'a', long: 'aaa', desc: 'opt a', argument: :optional,  multiple: true, hidden: false, block: nil, default: nil },
-            { short: 'b', long: 'bbb', desc: 'opt b', argument: :required,  multiple: false, hidden: false, block: nil, default: nil },
-            { short: 'c', long: 'ccc', desc: 'opt c', argument: :optional,  multiple: false, hidden: false, block: nil, default: nil },
-            { short: 'd', long: 'ddd', desc: 'opt d', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil },
-            { short: 'e', long: 'eee', desc: 'opt e', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil },
-            { short: 'f', long: 'fff', desc: 'opt f', argument: :forbidden, multiple: false, hidden: true,  block: nil, default: nil },
+            { short: 'a', long: 'aaa', desc: 'opt a', argument: :optional,  multiple: true,  hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'b', long: 'bbb', desc: 'opt b', argument: :required,  multiple: false, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'c', long: 'ccc', desc: 'opt c', argument: :optional,  multiple: false, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'd', long: 'ddd', desc: 'opt d', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'e', long: 'eee', desc: 'opt e', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'f', long: 'fff', desc: 'opt f', argument: :forbidden, multiple: false, hidden: true,  block: nil, default: nil, transform: nil },
           ],
         )
       actual_option_definitions = Set.new(command.option_definitions)
@@ -80,8 +80,8 @@ module Cri
       expected_option_definitions =
         Set.new(
           [
-            { short: 's', long: nil, desc: 'short', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil },
-            { short: nil, long: 'long', desc: 'long', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil },
+            { short: 's', long: nil,    desc: 'short', argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil, transform: nil },
+            { short: nil, long: 'long', desc: 'long',  argument: :forbidden, multiple: false, hidden: false, block: nil, default: nil, transform: nil },
           ],
         )
       actual_option_definitions = Set.new(command.option_definitions)
@@ -104,9 +104,9 @@ module Cri
       expected_option_definitions =
         Set.new(
           [
-            { short: 'f', long: 'flag',     desc: 'flag', argument: :forbidden, multiple: true, hidden: false, block: nil, default: nil },
-            { short: 'r', long: 'required', desc: 'req',  argument: :required,  multiple: true, hidden: false, block: nil, default: nil },
-            { short: 'o', long: 'optional', desc: 'opt',  argument: :optional,  multiple: true, hidden: false, block: nil, default: nil },
+            { short: 'f', long: 'flag',     desc: 'flag', argument: :forbidden, multiple: true, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'r', long: 'required', desc: 'req',  argument: :required,  multiple: true, hidden: false, block: nil, default: nil, transform: nil },
+            { short: 'o', long: 'optional', desc: 'opt',  argument: :optional,  multiple: true, hidden: false, block: nil, default: nil, transform: nil },
           ],
         )
       actual_option_definitions = Set.new(command.option_definitions)
@@ -129,9 +129,9 @@ module Cri
       expected_option_definitions =
         Set.new(
           [
-            { short: 'f', long: 'flag',     desc: 'flag', argument: :forbidden, multiple: false, hidden: true, block: nil, default: nil },
-            { short: 'r', long: 'required', desc: 'req',  argument: :required,  multiple: false, hidden: true, block: nil, default: nil },
-            { short: 'o', long: 'optional', desc: 'opt',  argument: :optional,  multiple: false, hidden: true, block: nil, default: nil },
+            { short: 'f', long: 'flag',     desc: 'flag', argument: :forbidden, multiple: false, hidden: true, block: nil, default: nil, transform: nil },
+            { short: 'r', long: 'required', desc: 'req',  argument: :required,  multiple: false, hidden: true, block: nil, default: nil, transform: nil },
+            { short: 'o', long: 'optional', desc: 'opt',  argument: :optional,  multiple: false, hidden: true, block: nil, default: nil, transform: nil },
           ],
         )
       actual_option_definitions = Set.new(command.option_definitions)


### PR DESCRIPTION
This adds support for transforming options. For example:

```ruby
option :p, :port, 'set port', argument: :required, transform: method(:Integer)
```

Exceptions are handled appropriately. For example, `--port nope` will cause Cri to fail with the following message:

```
serve: invalid value "nope" for --port option
```

Default values are not transformed. For example:

```ruby
option :p, :port, 'set port', argument: :required, default: 8080,
  transform: PortTransformer.new
```

… works as expected when not passing `--port`: the value will be `8080` and the transformer will not be called.