### PR TITLE
Allow specifying no_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,30 @@ end
 The command in this example has one parameter named `filename`. This means that
 the command takes a single argument, named `filename`.
 
+If no parameters are specified, Cri performs no argument parsing or validation; any number of arguments is allowed. To explicitly specify that a command has no parameters, use `#no_params`:
+
+```ruby
+name        'reset'
+usage       'reset'
+summary     'resets the site'
+description '…'
+no_params
+
+run do |opts, args, cmd|
+  puts "Resetting…"
+end
+```
+
+```
+% my-tool reset x
+reset: incorrect number of arguments given: expected 0, but got 1
+% my-tool reset
+Resetting…
+%
+```
+
+A future version of Cri will likely make `#no_params` the default behavior.
+
 (*Why the distinction between argument and parameter?* A parameter is a name, e.g. `filename`, while an argument is a value for a parameter, e.g. `kitten.jpg`.)
 
 ### The run block

--- a/lib/cri/argument_list.rb
+++ b/lib/cri/argument_list.rb
@@ -17,8 +17,9 @@ module Cri
 
     include Enumerable
 
-    def initialize(raw_arguments, param_defns)
+    def initialize(raw_arguments, explicitly_no_params, param_defns)
       @raw_arguments = raw_arguments
+      @explicitly_no_params = explicitly_no_params
       @param_defns = param_defns
 
       load
@@ -56,8 +57,8 @@ module Cri
       @arguments_array = @raw_arguments.reject { |a| a == '--' }.freeze
       @arguments_hash = {}
 
-      if @param_defns.empty?
-        # For now, don’t check arguments when no parameter definitions are given.
+      if !@explicitly_no_params && @param_defns.empty?
+        # No parameters defined; ignore
         return
       end
 

--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -93,6 +93,10 @@ module Cri
     # @return [Array<Hash>] The list of parameter definitions
     attr_accessor :parameter_definitions
 
+    # @return [Boolean] Whether or not this command has parameters
+    attr_accessor :explicitly_no_params
+    alias explicitly_no_params? explicitly_no_params
+
     # @return [Proc] The block that should be executed when invoking this
     #   command (ignored for commands with subcommands)
     attr_accessor :block
@@ -151,6 +155,7 @@ module Cri
       @commands           = Set.new
       @option_definitions = Set.new
       @parameter_definitions = []
+      @explicitly_no_params = false
       @default_subcommand_name = nil
     end
 
@@ -319,6 +324,7 @@ module Cri
           opts_and_args,
           global_option_definitions,
           parameter_definitions,
+          explicitly_no_params?,
         )
         handle_errors_while { parser.run }
         local_opts  = parser.options
@@ -378,6 +384,7 @@ module Cri
         opts_and_args,
         global_option_definitions,
         parameter_definitions,
+        explicitly_no_params?,
       )
       parser.delegate = delegate
       handle_errors_while { parser.run }

--- a/lib/cri/option_parser.rb
+++ b/lib/cri/option_parser.rb
@@ -114,10 +114,11 @@ module Cri
     #
     # @param [Array<Cri::ParamDefinition>] param_defns An array of parameter
     #   definitions
-    def initialize(arguments_and_options, option_defns, param_defns)
+    def initialize(arguments_and_options, option_defns, param_defns, explicitly_no_params)
       @unprocessed_arguments_and_options = arguments_and_options.dup
       @option_defns = option_defns
       @param_defns = param_defns
+      @explicitly_no_params = explicitly_no_params
 
       @options       = {}
       @raw_arguments = []
@@ -179,7 +180,7 @@ module Cri
     # @return [Cri::ArgumentList] The list of arguments that have already been
     #   parsed, excluding the -- separator.
     def arguments
-      ArgumentList.new(@raw_arguments, @param_defns)
+      ArgumentList.new(@raw_arguments, @explicitly_no_params, @param_defns)
     end
 
     private

--- a/samples/sample_basic_root.rb
+++ b/samples/sample_basic_root.rb
@@ -15,6 +15,7 @@ cmd.define_command do
   usage       'compile [options]'
   summary     'compiles a web site'
   description 'This loads all data, compiles it and writes it to the disk.'
+  no_params
 
   run do |_opts, _args|
     puts 'Compiling…'

--- a/test/test_argument_list.rb
+++ b/test/test_argument_list.rb
@@ -5,7 +5,7 @@ require 'helper'
 module Cri
   class ArgumentListTestCase < Cri::TestCase
     def test_empty
-      args = Cri::ArgumentList.new([], [])
+      args = Cri::ArgumentList.new([], false, [])
 
       assert_equal([], args.to_a)
       assert(args.empty?)
@@ -15,7 +15,7 @@ module Cri
     end
 
     def test_no_param_defns
-      args = Cri::ArgumentList.new(%w[a b c], [])
+      args = Cri::ArgumentList.new(%w[a b c], false, [])
 
       assert_equal(%w[a b c], args.to_a)
       refute(args.empty?)
@@ -28,13 +28,13 @@ module Cri
     end
 
     def test_enum
-      args = Cri::ArgumentList.new(%w[a b c], [])
+      args = Cri::ArgumentList.new(%w[a b c], false, [])
 
       assert_equal(%w[A B C], args.map(&:upcase))
     end
 
     def test_no_method_error
-      args = Cri::ArgumentList.new(%w[a b c], [])
+      args = Cri::ArgumentList.new(%w[a b c], false, [])
 
       refute args.respond_to?(:oink)
       assert_raises(NoMethodError, 'x') do
@@ -43,14 +43,14 @@ module Cri
     end
 
     def test_dash_dash
-      args = Cri::ArgumentList.new(%w[a -- b -- c], [])
+      args = Cri::ArgumentList.new(%w[a -- b -- c], false, [])
 
       assert_equal(%w[a b c], args.to_a)
     end
 
     def test_one_param_defn_matched
       param_defns = [Cri::ParamDefinition.new(name: 'filename')]
-      args = Cri::ArgumentList.new(%w[notbad.jpg], param_defns)
+      args = Cri::ArgumentList.new(%w[notbad.jpg], false, param_defns)
 
       assert_equal(['notbad.jpg'], args.to_a)
       assert_equal(1, args.size)
@@ -62,7 +62,7 @@ module Cri
       param_defns = [Cri::ParamDefinition.new(name: 'filename')]
 
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
-        Cri::ArgumentList.new(%w[notbad.jpg verybad.jpg], param_defns)
+        Cri::ArgumentList.new(%w[notbad.jpg verybad.jpg], false, param_defns)
       end
       assert_equal('incorrect number of arguments given: expected 1, but got 2', exception.message)
     end
@@ -71,9 +71,24 @@ module Cri
       param_defns = [Cri::ParamDefinition.new(name: 'filename')]
 
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
-        Cri::ArgumentList.new(%w[], param_defns)
+        Cri::ArgumentList.new(%w[], false, param_defns)
       end
       assert_equal('incorrect number of arguments given: expected 1, but got 0', exception.message)
+    end
+
+    def test_zero_params_zero_args
+      args = Cri::ArgumentList.new(%w[], false, [])
+
+      assert_equal([], args.to_a)
+      assert args.empty?
+      assert_equal(0, args.size)
+    end
+
+    def test_zero_params_one_arg
+      exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
+        Cri::ArgumentList.new(%w[a], true, [])
+      end
+      assert_equal('incorrect number of arguments given: expected 0, but got 1', exception.message)
     end
   end
 end

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -714,5 +714,47 @@ module Cri
       assert_equal [], lines(out)
       assert_equal ['publish: incorrect number of arguments given: expected 1, but got 0'], lines(err)
     end
+
+    def test_no_params_zero_args
+      dsl = Cri::CommandDSL.new
+      dsl.instance_eval do
+        name        'moo'
+        usage       'dunno whatever'
+        summary     'does stuff'
+        description 'This command does a lot of stuff.'
+        no_params
+
+        run do |_opts, args|
+        end
+      end
+      command = dsl.command
+
+      command.run([])
+    end
+
+    def test_no_params_one_arg
+      dsl = Cri::CommandDSL.new
+      dsl.instance_eval do
+        name        'moo'
+        usage       'dunno whatever'
+        summary     'does stuff'
+        description 'This command does a lot of stuff.'
+        no_params
+
+        run do |_opts, args|
+        end
+      end
+      command = dsl.command
+
+      out, err = capture_io_while do
+        err = assert_raises SystemExit do
+          command.run(['a'])
+        end
+        assert_equal 1, err.status
+      end
+
+      assert_equal [], lines(out)
+      assert_equal ['moo: incorrect number of arguments given: expected 0, but got 1'], lines(err)
+    end
   end
 end

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -268,5 +268,35 @@ module Cri
       assert_equal({ foo: 'a', bar: 'b', qux: 'c' }, $args_num)
       assert_equal({ foo: 'a', bar: 'b', qux: 'c' }, $args_sym)
     end
+
+    def test_no_params_with_one_param_specified
+      dsl = Cri::CommandDSL.new
+      err = assert_raises Cri::CommandDSL::AlreadySpecifiedWithParams do
+        dsl.instance_eval do
+          name        'moo'
+          usage       'dunno whatever'
+          summary     'does stuff'
+          description 'This command does a lot of stuff.'
+          param :oink
+          no_params
+        end
+      end
+      assert_equal('Attempted to declare the command "moo" as taking no parameters, but some parameters are already declared for this command. Suggestion: remove the #no_params call.', err.message)
+    end
+
+    def test_one_param_with_no_params_specified
+      dsl = Cri::CommandDSL.new
+      err = assert_raises Cri::CommandDSL::AlreadySpecifiedAsNoParams do
+        dsl.instance_eval do
+          name        'moo'
+          usage       'dunno whatever'
+          summary     'does stuff'
+          description 'This command does a lot of stuff.'
+          no_params
+          param :oink
+        end
+      end
+      assert_equal('Attempted to specify a parameter :oink to the command "moo", which is already specified as taking no params. Suggestion: remove the #no_params call.', err.message)
+    end
   end
 end

--- a/test/test_option_parser.rb
+++ b/test/test_option_parser.rb
@@ -8,7 +8,7 @@ module Cri
       input = %w[foo bar baz]
       opt_defns = []
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({}, parser.options)
       assert_equal(%w[foo bar baz], parser.arguments.to_a)
@@ -19,7 +19,7 @@ module Cri
       opt_defns = []
 
       assert_raises(Cri::OptionParser::IllegalOptionError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -29,7 +29,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(!parser.options[:aaa])
     end
@@ -40,7 +40,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert_equal(%w[foo bar], parser.arguments.to_a)
@@ -52,7 +52,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :required },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: 'xxx' }, parser.options)
       assert_equal(%w[foo bar], parser.arguments.to_a)
@@ -64,7 +64,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :required },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: 'xxx' }, parser.options)
       assert_equal(%w[foo bar], parser.arguments.to_a)
@@ -77,7 +77,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -89,7 +89,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -99,7 +99,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :optional },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert_equal(['foo'], parser.arguments.to_a)
@@ -111,7 +111,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :optional },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: 'xxx' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -125,7 +125,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert(parser.options[:bbb])
@@ -139,7 +139,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert_equal(%w[foo bar], parser.arguments.to_a)
@@ -152,7 +152,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -164,7 +164,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert(parser.options[:bbb])
@@ -180,7 +180,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal('bar', parser.options[:aaa])
       assert(parser.options[:bbb])
@@ -196,7 +196,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -206,7 +206,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :optional },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert_equal(['foo'], parser.arguments.to_a)
@@ -218,7 +218,7 @@ module Cri
         { long: 'aaa', short: 'a', argument: :optional },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: 'xxx' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -232,7 +232,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :forbidden },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert(parser.options[:aaa])
       assert(parser.options[:bbb])
@@ -244,7 +244,7 @@ module Cri
       input = %w[foo - bar]
       opt_defns = []
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({}, parser.options)
       assert_equal(['foo', '-', 'bar'], parser.arguments.to_a)
@@ -254,7 +254,7 @@ module Cri
       input = %w[foo bar -- -x --yyy -abc]
       opt_defns = []
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({}, parser.options)
       assert_equal(['foo', 'bar', '-x', '--yyy', '-abc'], parser.arguments.to_a)
@@ -267,7 +267,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -278,7 +278,7 @@ module Cri
         { long: 'verbose', short: 'v', multiple: true },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal(%w[test test2], parser.options[:long])
       assert_equal(3, parser.options[:verbose].size)
@@ -290,7 +290,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :required, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'donkey' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -303,7 +303,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       assert_raises(Cri::OptionParser::OptionRequiresAnArgumentError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
     end
 
@@ -313,7 +313,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :required, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'giraffe' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -325,7 +325,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'donkey' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -337,7 +337,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'donkey' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -349,7 +349,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'giraffe' }, parser.options)
       assert_equal(['foo'], parser.arguments.to_a)
@@ -361,7 +361,7 @@ module Cri
         { long: 'animal', short: 'a', argument: :optional, default: 'donkey' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ animal: 'gi' }, parser.options)
       assert_equal(%w[foo raffe], parser.arguments.to_a)
@@ -375,7 +375,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :required },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: true, bbb: 'xxx', ccc: 'yyy' }, parser.options)
       assert_equal(%w[foo zzz], parser.arguments.to_a)
@@ -389,7 +389,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :required },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: true, bbb: 'xxx', ccc: 'yyy' }, parser.options)
       assert_equal(%w[foo zzz], parser.arguments.to_a)
@@ -403,7 +403,7 @@ module Cri
         { long: 'ccc', short: 'c', argument: :optional, default: 'c default' },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ aaa: true, bbb: 'xxx', ccc: 'c default' }, parser.options)
       assert_equal(%w[foo], parser.arguments.to_a)
@@ -415,7 +415,7 @@ module Cri
         { long: 'port', short: 'p', argument: :required, transform: ->(x) { Integer(x) } },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ port: 123 }, parser.options)
       assert_equal([], parser.arguments.to_a)
@@ -427,7 +427,7 @@ module Cri
         { long: 'port', short: 'p', argument: :required, transform: method(:Integer) },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ port: 123 }, parser.options)
       assert_equal([], parser.arguments.to_a)
@@ -445,7 +445,7 @@ module Cri
         { long: 'port', short: 'p', argument: :required, transform: port },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ port: 123 }, parser.options)
       assert_equal([], parser.arguments.to_a)
@@ -464,7 +464,7 @@ module Cri
         { long: 'port', short: 'p', argument: :required, default: 8080, transform: port },
       ].map { |hash| make_opt_defn(hash) }
 
-      parser = Cri::OptionParser.new(input, opt_defns, []).run
+      parser = Cri::OptionParser.new(input, opt_defns, [], false).run
 
       assert_equal({ port: 8080 }, parser.options)
       assert_equal([], parser.arguments.to_a)
@@ -477,7 +477,7 @@ module Cri
       ].map { |hash| make_opt_defn(hash) }
 
       exception = assert_raises(Cri::OptionParser::IllegalOptionValueError) do
-        Cri::OptionParser.new(input, opt_defns, []).run
+        Cri::OptionParser.new(input, opt_defns, [], false).run
       end
       assert_equal('invalid value "one_hundred_and_twenty_three" for --port option', exception.message)
     end
@@ -488,7 +488,7 @@ module Cri
         { name: 'host' },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
-      parser = Cri::OptionParser.new(input, [], param_defns).run
+      parser = Cri::OptionParser.new(input, [], param_defns, false).run
       assert_equal({}, parser.options)
       assert_equal('localhost', parser.arguments[0])
       assert_equal('localhost', parser.arguments[:host])
@@ -500,7 +500,7 @@ module Cri
         { name: 'host' },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
-      parser = Cri::OptionParser.new(input, [], param_defns).run
+      parser = Cri::OptionParser.new(input, [], param_defns, false).run
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
         parser.arguments
       end
@@ -513,7 +513,7 @@ module Cri
         { name: 'host' },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
-      parser = Cri::OptionParser.new(input, [], param_defns).run
+      parser = Cri::OptionParser.new(input, [], param_defns, false).run
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
         parser.arguments
       end
@@ -526,7 +526,7 @@ module Cri
         { name: 'host' },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
-      parser = Cri::OptionParser.new(input, [], param_defns).run
+      parser = Cri::OptionParser.new(input, [], param_defns, false).run
 
       exception = assert_raises(ArgumentError) do
         parser.arguments['oink']
@@ -541,7 +541,7 @@ module Cri
         { name: 'target' },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
-      parser = Cri::OptionParser.new(input, [], param_defns).run
+      parser = Cri::OptionParser.new(input, [], param_defns, false).run
       assert_equal({}, parser.options)
       assert_equal('localhost', parser.arguments[0])
       assert_equal('localhost', parser.arguments[:source])


### PR DESCRIPTION
This adds `no_params`, which explicitly defines a command as taking no arguments.

Example:

```ruby
command = Cri::Command.define do
  name        'reset'
  usage       'reset'
  summary     'resets the site'
  description '…'
  no_params

  run do |opts, args, cmd|
    puts "Resetting…"
  end
end
```

```
% my-tool reset x
reset: incorrect number of arguments given: expected 0, but got 1
% my-tool reset
Resetting…
%
```
