### PR TITLE
Implement parameter transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,12 @@ Resetting…
 
 A future version of Cri will likely make `#no_params` the default behavior.
 
+As with options, parameter definitions take `transform:`, which can be used for transforming and validating arguments:
+
+```ruby
+param :port, transform: method(:Integer)
+```
+
 (*Why the distinction between argument and parameter?* A parameter is a name, e.g. `filename`, while an argument is a value for a parameter, e.g. `kitten.jpg`.)
 
 ### The run block

--- a/lib/cri/argument_list.rb
+++ b/lib/cri/argument_list.rb
@@ -54,20 +54,25 @@ module Cri
     end
 
     def load
-      @arguments_array = @raw_arguments.reject { |a| a == '--' }.freeze
+      @arguments_array = []
       @arguments_hash = {}
+
+      arguments_array = @raw_arguments.reject { |a| a == '--' }.freeze
 
       if !@explicitly_no_params && @param_defns.empty?
         # No parameters defined; ignore
+        @arguments_array = arguments_array
         return
       end
 
-      if @arguments_array.size != @param_defns.size
-        raise ArgumentCountMismatchError.new(@param_defns.size, @arguments_array.size)
+      if arguments_array.size != @param_defns.size
+        raise ArgumentCountMismatchError.new(@param_defns.size, arguments_array.size)
       end
 
-      @arguments_array.zip(@param_defns).each do |(arg, param_defn)|
+      arguments_array.zip(@param_defns).each do |(arg, param_defn)|
+        arg = param_defn.transform ? param_defn.transform.call(arg) : arg
         @arguments_hash[param_defn.name.to_sym] = arg
+        @arguments_array << arg
       end
     end
   end

--- a/lib/cri/command_dsl.rb
+++ b/lib/cri/command_dsl.rb
@@ -170,12 +170,15 @@ module Cri
     # Defines a new parameter for the command.
     #
     # @param [Symbol] name The name of the parameter
-    def param(name)
+    def param(name, transform: nil)
       if @command.explicitly_no_params?
         raise AlreadySpecifiedAsNoParams.new(name, @command)
       end
 
-      @command.parameter_definitions << Cri::ParamDefinition.new(name: name)
+      @command.parameter_definitions << Cri::ParamDefinition.new(
+        name: name,
+        transform: transform,
+      )
     end
 
     def no_params

--- a/lib/cri/param_definition.rb
+++ b/lib/cri/param_definition.rb
@@ -4,9 +4,11 @@ module Cri
   # The definition of a parameter.
   class ParamDefinition
     attr_reader :name
+    attr_reader :transform
 
-    def initialize(name:)
+    def initialize(name:, transform:)
       @name = name
+      @transform = transform
     end
   end
 end

--- a/test/test_argument_list.rb
+++ b/test/test_argument_list.rb
@@ -49,7 +49,7 @@ module Cri
     end
 
     def test_one_param_defn_matched
-      param_defns = [Cri::ParamDefinition.new(name: 'filename')]
+      param_defns = [Cri::ParamDefinition.new(name: 'filename', transform: nil)]
       args = Cri::ArgumentList.new(%w[notbad.jpg], false, param_defns)
 
       assert_equal(['notbad.jpg'], args.to_a)
@@ -59,7 +59,7 @@ module Cri
     end
 
     def test_one_param_defn_too_many
-      param_defns = [Cri::ParamDefinition.new(name: 'filename')]
+      param_defns = [Cri::ParamDefinition.new(name: 'filename', transform: nil)]
 
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
         Cri::ArgumentList.new(%w[notbad.jpg verybad.jpg], false, param_defns)
@@ -68,7 +68,7 @@ module Cri
     end
 
     def test_one_param_defn_too_few
-      param_defns = [Cri::ParamDefinition.new(name: 'filename')]
+      param_defns = [Cri::ParamDefinition.new(name: 'filename', transform: nil)]
 
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
         Cri::ArgumentList.new(%w[], false, param_defns)
@@ -89,6 +89,16 @@ module Cri
         Cri::ArgumentList.new(%w[a], true, [])
       end
       assert_equal('incorrect number of arguments given: expected 0, but got 1', exception.message)
+    end
+
+    def test_transform
+      param_defns = [Cri::ParamDefinition.new(name: 'filename', transform: ->(a) { a.upcase })]
+      args = Cri::ArgumentList.new(%w[notbad.jpg], false, param_defns)
+
+      assert_equal(['NOTBAD.JPG'], args.to_a)
+      assert_equal(1, args.size)
+      assert_equal('NOTBAD.JPG', args[0])
+      assert_equal('NOTBAD.JPG', args[:filename])
     end
   end
 end

--- a/test/test_command_dsl.rb
+++ b/test/test_command_dsl.rb
@@ -269,6 +269,32 @@ module Cri
       assert_equal({ foo: 'a', bar: 'b', qux: 'c' }, $args_sym)
     end
 
+    def test_params_transform
+      # Define
+      dsl = Cri::CommandDSL.new
+      dsl.instance_eval do
+        name        'moo'
+        usage       'dunno whatever'
+        summary     'does stuff'
+        description 'This command does a lot of stuff.'
+
+        param :foo, transform: ->(a) { a.upcase }
+
+        run do |_opts, args|
+          $args_num = { foo: args[0] }
+          $args_sym = { foo: args[:foo] }
+        end
+      end
+      command = dsl.command
+
+      # Run
+      $args_num = '???'
+      $args_sym = '???'
+      command.run(%w[abc])
+      assert_equal({ foo: 'ABC' }, $args_num)
+      assert_equal({ foo: 'ABC' }, $args_sym)
+    end
+
     def test_no_params_with_one_param_specified
       dsl = Cri::CommandDSL.new
       err = assert_raises Cri::CommandDSL::AlreadySpecifiedWithParams do

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -485,7 +485,7 @@ module Cri
     def test_parse_with_param_defns
       input       = %w[localhost]
       param_defns = [
-        { name: 'host' },
+        { name: 'host', transform: nil },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
@@ -497,7 +497,7 @@ module Cri
     def test_parse_with_param_defns_too_few_args
       input       = []
       param_defns = [
-        { name: 'host' },
+        { name: 'host', transform: nil },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
@@ -510,7 +510,7 @@ module Cri
     def test_parse_with_param_defns_too_many_args
       input       = %w[localhost oink]
       param_defns = [
-        { name: 'host' },
+        { name: 'host', transform: nil },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
@@ -523,7 +523,7 @@ module Cri
     def test_parse_with_param_defns_invalid_key
       input       = %w[localhost]
       param_defns = [
-        { name: 'host' },
+        { name: 'host', transform: nil },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
@@ -537,8 +537,8 @@ module Cri
     def test_parse_with_param_defns_two_params
       input       = %w[localhost example.com]
       param_defns = [
-        { name: 'source' },
-        { name: 'target' },
+        { name: 'source', transform: nil },
+        { name: 'target', transform: nil },
       ].map { |hash| Cri::ParamDefinition.new(hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run


### PR DESCRIPTION
This allows transforming parameters. Example:

```ruby
param :id, transform: ->(a) { a.upcase }
```

When given `abc123` as argument, `arguments[:id]` will be `ABC123`.