### PR TITLE
Let ArgumentList#each return enumerator unless block given

### DIFF
--- a/lib/cri/argument_list.rb
+++ b/lib/cri/argument_list.rb
@@ -37,6 +37,8 @@ module Cri
     end
 
     def each
+      return to_enum(__method__) unless block_given?
+
       @arguments_array.each { |e| yield(e) }
       self
     end

--- a/test/test_argument_list.rb
+++ b/test/test_argument_list.rb
@@ -33,6 +33,12 @@ module Cri
       assert_equal(%w[A B C], args.map(&:upcase))
     end
 
+    def test_enum_without_block
+      args = Cri::ArgumentList.new(%w[a b c], false, [])
+
+      assert_equal(%w[A B C], args.each.map(&:upcase))
+    end
+
     def test_no_method_error
       args = Cri::ArgumentList.new(%w[a b c], false, [])
 


### PR DESCRIPTION
Calling `ArgumentList#each` now works even when not passed a block, in which case it will return an `Enumerator`:

```ruby
args = Cri::ArgumentList.new(%w[a b c], false, [])
args.each.map(&:upcase) 
# => ['A', 'B', 'C']
```

Fixes #87.