### PR TITLE
Remove dependency on colored

### DIFF
--- a/cri.gemspec
+++ b/cri.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.4'
 
-  s.add_dependency('colored', '~> 1.2')
-
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md', 'NEWS.md']
 end

--- a/lib/cri.rb
+++ b/lib/cri.rb
@@ -20,8 +20,6 @@ end
 
 require 'set'
 
-require 'colored'
-
 require_relative 'cri/version'
 require_relative 'cri/argument_list'
 require_relative 'cri/command'

--- a/lib/cri/string_formatter.rb
+++ b/lib/cri/string_formatter.rb
@@ -82,7 +82,7 @@ module Cri
     #   in the help
     def format_as_title(str, io)
       if Cri::Platform.color?(io)
-        str.upcase.red.bold
+        bold(red(str.upcase))
       else
         str.upcase
       end
@@ -94,7 +94,7 @@ module Cri
     #   in the help
     def format_as_command(str, io)
       if Cri::Platform.color?(io)
-        str.green
+        green(str)
       else
         str
       end
@@ -106,10 +106,26 @@ module Cri
     #   of a command in the help
     def format_as_option(str, io)
       if Cri::Platform.color?(io)
-        str.yellow
+        yellow(str)
       else
         str
       end
+    end
+
+    def red(str)
+      "\e[31m#{str}\e[0m"
+    end
+
+    def green(str)
+      "\e[32m#{str}\e[0m"
+    end
+
+    def yellow(str)
+      "\e[33m#{str}\e[0m"
+    end
+
+    def bold(str)
+      "\e[1m#{str}\e[0m"
     end
   end
 end


### PR DESCRIPTION
Fixes #89.

Rather than using `colored` (or any other gem) to provide us with ANSI escape codes, let’s generate the ANSI escape codes ourselves. (They’re quite easy to generate.)