### PR TITLE
If summary is missing, print name anyway

### DIFF
--- a/lib/cri/help_renderer.rb
+++ b/lib/cri/help_renderer.rb
@@ -45,10 +45,16 @@ module Cri
     end
 
     def append_summary(text)
-      return if @cmd.summary.nil?
+      return if @cmd.name.nil?
 
       text << fmt.format_as_title('name', @io) << "\n"
-      text << "    #{fmt.format_as_command(@cmd.name, @io)} - #{@cmd.summary}" << "\n"
+
+      text << '    ' << fmt.format_as_command(@cmd.name, @io)
+      if @cmd.summary
+        text << ' - ' << @cmd.summary
+      end
+      text << "\n"
+
       unless @cmd.aliases.empty?
         text << '    aliases: ' << @cmd.aliases.map { |a| fmt.format_as_command(a, @io) }.join(' ') << "\n"
       end

--- a/test/test_help_renderer.rb
+++ b/test/test_help_renderer.rb
@@ -43,5 +43,30 @@ module Cri
 
       assert_match(/^       --with-animal\[=<value>\]      Add animal \(default: giraffe\)$/, help)
     end
+
+    def test_with_summary
+      cmd = Cri::Command.define do
+        name 'build'
+        summary 'do some buildage'
+
+        optional nil, :'with-animal', 'Add animal', default: 'giraffe'
+      end
+
+      help = help_for(cmd)
+
+      assert_match(/^NAME\n    build - do some buildage\n$/, help)
+    end
+
+    def test_without_summary
+      cmd = Cri::Command.define do
+        name 'build'
+
+        optional nil, :'with-animal', 'Add animal', default: 'giraffe'
+      end
+
+      help = help_for(cmd)
+
+      assert_match(/^NAME\n    build\n$/, help)
+    end
   end
 end


### PR DESCRIPTION
When a command has a name but no summary, nothing would be printed as the summary. With this change, only the name is printed, e.g.

```
NAME
    build
```

rather than (if the summary were present)

```
NAME
    build - do some build stuff
```

Fixes #92.