### PR TITLE
Add compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ nested commands.
 
 Cri requires Ruby 2.3 or newer.
 
+## Compatibility policy
+
+Cri is guaranteed to be supported on any [officially supported Ruby version](https://www.ruby-lang.org/en/downloads/branches/), as well as the version of Ruby that comes by default on
+
+* the last two [Ubuntu LTS releases](https://wiki.ubuntu.com/Releases)
+* the last two major [macOS releases](https://en.wikipedia.org/wiki/MacOS_version_history)
+
 ## Usage
 
 The central concept in Cri is the _command_, which has option definitions as


### PR DESCRIPTION
This adds a compatibility policy which should make it clear which versions of Ruby are supported — not just the officially-supported ones. This came out of a discussion in #91 — see that issue for details.

@scotje @binford2k @donoghuc Could you take a look and let me know what you think?

## Open questions

*   Once we drop Ruby 2.3 support (presumably in 2021), what will we do to the version number? Semantic Versioning does not clearly prescribe how to proceed in this case.

    This is a concern that does not need to be solved right now — it can wait until 2012. :)

## Related issues

Fixes #91.