### PR TITLE
Don’t set default options as explicit keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,33 @@ OPTIONS
     -a --animal[=<value>]      add animal (default: giraffe)
 ```
 
+If the option is not given on the command line, the `options` hash will not have key for this option, but will still have a default value:
+
+```ruby
+option :a, :animal, 'add animal', default: 'giraffe', argument: :required
+
+run do |opts, args, cmd|
+  puts "Animal = #{opts[:animal]}"
+  puts "Option given? #{opts.key?(:animal)}"
+end
+```
+
+```sh
+% ./run --animal=donkey
+Animal = donkey
+Option given? true
+
+% ./run --animal=giraffe
+Animal = giraffe
+Option given? true
+
+% ./run
+Animal = giraffe
+Option given? false
+```
+
+This can be useful to distinguish between an explicitly-passed-in value and a default value. In the example above, the `animal` option is set to `giraffe` in the second and third cases, but it is possible to detect whether the value is a default or not.
+
 #### Multivalued options (`multiple:`)
 
 The `:multiple` parameter allows an option to be specified more than once on the command line. When set to `true`, multiple option valus are accepted, and the option values will be stored in an array.

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -126,7 +126,7 @@ module Cri
         simple_cmd.run(%w[])
       end
 
-      assert_equal ['Awesome moo!', '', 'ddd=false,eee=false'], lines(out)
+      assert_equal ['Awesome moo!', '', ''], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -135,7 +135,7 @@ module Cri
         simple_cmd.run(%w[abc xyz])
       end
 
-      assert_equal ['Awesome moo!', 'abc,xyz', 'ddd=false,eee=false'], lines(out)
+      assert_equal ['Awesome moo!', 'abc,xyz', ''], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -144,7 +144,7 @@ module Cri
         simple_cmd.run(%w[-c -b x])
       end
 
-      assert_equal ['Awesome moo!', '', 'bbb=x,ccc=true,ddd=false,eee=false'], lines(out)
+      assert_equal ['Awesome moo!', '', 'bbb=x,ccc=true'], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -216,7 +216,7 @@ module Cri
         simple_cmd.run(%w[-a 123])
       end
 
-      assert_equal ['moo:123', 'Awesome moo!', '', 'aaa=123,ddd=false,eee=false'], lines(out)
+      assert_equal ['moo:123', 'Awesome moo!', '', 'aaa=123'], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -246,7 +246,7 @@ module Cri
         nested_cmd.run(%w[sub])
       end
 
-      assert_equal ['Sub-awesome!', '', 'ddd=false,eee=false,ppp=false,qqq=false'], lines(out)
+      assert_equal ['Sub-awesome!', '', ''], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -297,7 +297,7 @@ module Cri
         nested_cmd.run(%w[sup])
       end
 
-      assert_equal ['Sub-awesome!', '', 'ddd=false,eee=false,ppp=false,qqq=false'], lines(out)
+      assert_equal ['Sub-awesome!', '', ''], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -306,7 +306,7 @@ module Cri
         nested_cmd.run(%w[-a 666 sub])
       end
 
-      assert_equal ['super:666', 'Sub-awesome!', '', 'aaa=666,ddd=false,eee=false,ppp=false,qqq=false'], lines(out)
+      assert_equal ['super:666', 'Sub-awesome!', '', 'aaa=666'], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -902,14 +902,14 @@ module Cri
         option :f, :force2, 'push with force', argument: :forbidden
 
         run do |opts, _args, _cmd|
-          puts "Force? #{opts[:force2].inspect}!"
+          puts "Force? #{opts[:force2].inspect}! Key present? #{opts.key?(:force2)}!"
         end
       end
 
       out, err = capture_io_while do
         cmd.run(%w[])
       end
-      assert_equal ['Force? false!'], lines(out)
+      assert_equal ['Force? false! Key present? false!'], lines(out)
       assert_equal [], lines(err)
     end
 
@@ -919,14 +919,14 @@ module Cri
         option :a, :animal, 'specify animal', argument: :required, default: 'cow'
 
         run do |opts, _args, _cmd|
-          puts "Animal = #{opts[:animal]}"
+          puts "Animal = #{opts[:animal]}! Key present? #{opts.key?(:animal)}!"
         end
       end
 
       out, err = capture_io_while do
         cmd.run(%w[])
       end
-      assert_equal ['Animal = cow'], lines(out)
+      assert_equal ['Animal = cow! Key present? false!'], lines(out)
       assert_equal [], lines(err)
     end
 


### PR DESCRIPTION
By setting default values for options explicitly, i.e. using #[]=, it becomes impossible to distinguish beteen explicity-specified options and implicitly-defaulted options. By using Hash#new, it becomes possible to return default values but not have them explicitly set as keys.

For example:

```ruby
option :a, :animal, 'add animal', default: 'giraffe', argument: :required

run do |opts, args, cmd|
  puts "Animal = #{opts[:animal]}"
  puts "Option given? #{opts.key?(:animal)}"
end
```

```sh
% ./run --animal=donkey
Animal = donkey
Option given? true

% ./run --animal=giraffe
Animal = giraffe
Option given? true

% ./run
Animal = giraffe
Option given? false
```

See #94.