### PR TITLE
Fix bug which causes option definitions to be merged

### DIFF
--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -361,7 +361,11 @@ module Cri
     end
 
     def all_opt_defns
-      supercommand ? supercommand.all_opt_defns.merge(option_definitions) : option_definitions
+      if supercommand
+        supercommand.all_opt_defns | option_definitions
+      else
+        option_definitions
+      end
     end
 
     # @return [String] The help text for this command


### PR DESCRIPTION
Fixes #101.

Lesson learnt: `Hash#merge` does not mutate anything, but `Set#new` does…