### PR TITLE
Add Ruby 2.7 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 before_install:
   - gem update --remote bundler
   - gem update --system

--- a/lib/cri/command.rb
+++ b/lib/cri/command.rb
@@ -343,7 +343,7 @@ module Cri
           explicitly_no_params?,
         )
         handle_errors_while { parser.run }
-        local_opts  = parser.options
+        local_opts = parser.options
         global_opts = parent_opts.merge(parser.options)
         global_opts = add_defaults(global_opts)
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -549,7 +549,7 @@ module Cri
     end
 
     def test_hidden_commands_multiple
-      cmd    = nested_cmd
+      cmd = nested_cmd
 
       subcmd = simple_cmd
       cmd.add_command subcmd


### PR DESCRIPTION
Ruby 2.7 got released some time ago. More and more distributions ship it
so I think we should also run the tests on it.