### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
 
 # Trailing commas in a multiline context makes diffs nicer.
@@ -77,4 +77,16 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Metrics/ParameterLists:
+  Enabled: false
+
+# The following cops were added to RuboCop 2.4
+Lint/RaiseException:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_install:
   - gem update --remote bundler
   - gem update --system

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ Features:
 
 - Adds support for Ruby 3.0 to match requirement in README `Cri requires Ruby 2.3 or newer.`
 
+Fixes: 
+
+- Fixed rubocop warning TargetRubyVersion 2.3 no loner supported.
+- Drop support for Ruby 2.3
+
 ## 2.15.10
 
 Fixes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Cri News
 
+## Upcoming
+
+Features: 
+
+- Adds support for Ruby 3.0 to match requirement in README `Cri requires Ruby 2.3 or newer.`
+
 ## 2.15.10
 
 Fixes:

--- a/cri.gemspec
+++ b/cri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['[A-Z]*'] + Dir['{lib,test}/**/*'] + ['cri.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '>= 2.3'
 
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md', 'NEWS.md']

--- a/cri.gemspec
+++ b/cri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['[A-Z]*'] + Dir['{lib,test}/**/*'] + ['cri.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md', 'NEWS.md']


### PR DESCRIPTION
with Ruby 3.0.0 I see the following error: 

```
cri-2.15.10 requires ruby version ~> 2.3, which is incompatible with the current version, ruby 3.0.0p0
```

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/