### PR TITLE
Support Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_install:
   - gem update --remote bundler
   - gem update --system

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ nested commands.
 
 ## Requirements
 
-Cri requires Ruby 2.5 or newer.
+Cri requires Ruby 2.5 or newer (including Ruby 3.x).
 
 ## Compatibility policy
 

--- a/cri.gemspec
+++ b/cri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['[A-Z]*'] + Dir['{lib,test}/**/*'] + ['cri.gemspec']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '~> 2.5'
+  s.required_ruby_version = '>= 2.5'
 
   s.rdoc_options     = ['--main', 'README.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md', 'NEWS.md']

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -443,7 +443,7 @@ module Cri
       input       = %w[localhost]
       param_defns = [
         { name: 'host', transform: nil },
-      ].map { |hash| Cri::ParamDefinition.new(hash) }
+      ].map { |hash| Cri::ParamDefinition.new(**hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
       assert_equal({}, parser.options)
@@ -455,7 +455,7 @@ module Cri
       input       = []
       param_defns = [
         { name: 'host', transform: nil },
-      ].map { |hash| Cri::ParamDefinition.new(hash) }
+      ].map { |hash| Cri::ParamDefinition.new(**hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
@@ -468,7 +468,7 @@ module Cri
       input       = %w[localhost oink]
       param_defns = [
         { name: 'host', transform: nil },
-      ].map { |hash| Cri::ParamDefinition.new(hash) }
+      ].map { |hash| Cri::ParamDefinition.new(**hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
       exception = assert_raises(Cri::ArgumentList::ArgumentCountMismatchError) do
@@ -481,7 +481,7 @@ module Cri
       input       = %w[localhost]
       param_defns = [
         { name: 'host', transform: nil },
-      ].map { |hash| Cri::ParamDefinition.new(hash) }
+      ].map { |hash| Cri::ParamDefinition.new(**hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
 
@@ -496,7 +496,7 @@ module Cri
       param_defns = [
         { name: 'source', transform: nil },
         { name: 'target', transform: nil },
-      ].map { |hash| Cri::ParamDefinition.new(hash) }
+      ].map { |hash| Cri::ParamDefinition.new(**hash) }
 
       parser = Cri::Parser.new(input, [], param_defns, false).run
       assert_equal({}, parser.options)


### PR DESCRIPTION
Based on #110.

This explicitly adds support for Ruby 3.x, and lets it be tested on Travis CI as well.